### PR TITLE
bumps react native svg to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
   "homepage": "https://github.com/EROIN/ReactNativeNetworkGraph#readme",
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-native-svg": "^5.1.8"
+    "react-native-svg": "^12.1.1"
   }
 }


### PR DESCRIPTION
There is an [open issue ](https://github.com/EROIN/ReactNativeNetworkGraph/issues/1) that this PR resolves by simply updating the linked react-native-svg version. Please merge